### PR TITLE
defaults: better wording

### DIFF
--- a/userconfig.js
+++ b/userconfig.js
@@ -107,7 +107,7 @@ const default_config = {
       background_url: "src/img/banners/cbg-8.gif",
       categories: [
         {
-          name: "resources",
+          name: "development",
           links: [
             {
               name: "github",
@@ -159,7 +159,7 @@ const default_config = {
           ],
         },
         {
-          name: "blogs",
+          name: "resources",
           links: [
             {
               name: "dou",
@@ -194,7 +194,7 @@ const default_config = {
       background_url: "src/img/banners/cbg-10.gif",
       categories: [
         {
-          name: "social medias",
+          name: "social media",
           links: [
             {
               name: "telegram",
@@ -217,7 +217,7 @@ const default_config = {
           ],
         },
         {
-          name: "games",
+          name: "gaming",
           links: [
             {
               name: "IGN",


### PR DESCRIPTION
Fixes wording in the default `userconfig.js`.

Changes:
- `resources` -> `development` | The name `resources` indicates that the content is primarily used for learning which is not the case with GitHub or Neptune
- `blogs` -> `resources` | While `blogs` isn't incorrect, IMO `resources` suits sites like Hacker News better
- `social medias` -> `social media` | Typo
- `games` -> `gaming` | `games` would indicate that the following links **are** games. Here, the links contain gaming-related content.

Feel free to push commits to my branch if this doesn't 100% match your preferences.
