### PR TITLE
fix: using clock icon color as defined in userconfig.js instead of hard-coded maroon

### DIFF
--- a/src/components/clock/clock.component.js
+++ b/src/components/clock/clock.component.js
@@ -36,7 +36,7 @@ class Clock extends Component {
   }
 
   setIconColor() {
-    this.refs.icon.style.color = CONFIG.palette.maroon;
+    this.refs.icon.style.color = CONFIG.clock.iconColor;
   }
 
   setTime() {


### PR DESCRIPTION
## fix: use user-defined color for clock icon

This change makes sure to apply the clock icon color defined in `userconfig.js` instead of hard-coding `COLOR.palette.maroon`.
