### PR TITLE
fix: add fastlink to config defaults

### DIFF
--- a/src/common/config.js
+++ b/src/common/config.js
@@ -46,6 +46,8 @@ class Config {
     },
     // List of disabled components
     disabled: [],
+    // URL to open when clicking the fastlink button in the statusbar
+    fastlink: "",
     // Whether to use local fonts instead of Google Fonts CDN
     localFonts: false,
     // Whether to restore last active tab on load


### PR DESCRIPTION
# Pull Request Checklist

## Summary

Commit 2832769 updated the statusbar to read `CONFIG.fastlink` directly,
but `fastlink` was never added to the `defaults` object in `config.js`.
Since `autoConfig()` only processes keys present in `defaults`, the value
is never copied to the top-level `CONFIG` object, leaving `CONFIG.fastlink`
undefined and the fastlink button non-functional.

This adds `fastlink: ""` to the defaults so `autoConfig()` correctly
propagates the user's value to `CONFIG.fastlink`.

## Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
